### PR TITLE
Support numeric arguments in break and continue

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
@@ -98,7 +98,7 @@ trait CompilesLoops
     {
         if ($expression) {
             preg_match('/\(\s*(\d)\s*\)$/', $expression, $matches);
-            return $matches ? '<?php break ' . $matches[1] . '; ?>' : "<?php if{$expression} break; ?>";
+            return $matches ? '<?php break ' . max(1, $matches[1]) . '; ?>' : "<?php if{$expression} break; ?>";
         }
 
         return '<?php break; ?>';
@@ -114,7 +114,7 @@ trait CompilesLoops
     {
         if ($expression) {
             preg_match('/\(\s*(\d)\s*\)$/', $expression, $matches);
-            return $matches ? '<?php continue ' . $matches[1] . '; ?>' : "<?php if{$expression} continue; ?>";
+            return $matches ? '<?php continue ' . max(1, $matches[1]) . '; ?>' : "<?php if{$expression} continue; ?>";
         }
 
         return '<?php continue; ?>';

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
@@ -96,7 +96,12 @@ trait CompilesLoops
      */
     protected function compileBreak($expression)
     {
-        return $expression ? "<?php if{$expression} break; ?>" : '<?php break; ?>';
+        if ($expression) {
+            preg_match('/\(\s*(\d)\s*\)$/', $expression, $matches);
+            return $matches ? '<?php break ' . $matches[1] . '; ?>' : "<?php if{$expression} break; ?>";
+        }
+
+        return '<?php break; ?>';
     }
 
     /**
@@ -107,7 +112,12 @@ trait CompilesLoops
      */
     protected function compileContinue($expression)
     {
-        return $expression ? "<?php if{$expression} continue; ?>" : '<?php continue; ?>';
+        if ($expression) {
+            preg_match('/\(\s*(\d)\s*\)$/', $expression, $matches);
+            return $matches ? '<?php continue ' . $matches[1] . '; ?>' : "<?php if{$expression} continue; ?>";
+        }
+
+        return '<?php continue; ?>';
     }
 
     /**


### PR DESCRIPTION
### Description
As per the [PHP documentation](http://php.net/manual/en/control-structures.break.php)
>break accepts an optional numeric argument which tells it how many nested enclosing structures are to be broken out of. The default value is 1, only the immediate enclosing structure is broken out of.

### Usage

To break out of 2 nested loops:

`@break(2)` compiles to `break 2;`

### Compatibility

* Previous expressions like `($user->id == 2)` are supported
* Checks for formatting with varying white-space: `@continue( 2 )` compiles to `continue 2;`
* Check the minimum amount of structures to break out of: 1
